### PR TITLE
chore: bump dependencies to latest versions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,15 +28,19 @@ export default defineConfig({
         "./src/styles/learn.css",
         "./src/styles/atom-one-light.min.css",
       ],
-      social: {
-        github: "https://github.com/interledger",
-        instagram: "https://www.instagram.com/interledgerfoundation/",
-        linkedin: "https://www.linkedin.com/company/interledger-foundation/",
-        mastodon: "https://interledger.social/about",
-        slack: "https://communityinviter.com/apps/interledger/interledger-working-groups-slack",
-        "x.com": "https://twitter.com/interledger",
-        youtube: "https://www.youtube.com/@InterledgerFoundation",
-      },
+      social: [
+        { icon: "github", label: "GitHub", href: "https://github.com/interledger" },
+        { icon: "instagram", label: "Instagram", href: "https://www.instagram.com/interledgerfoundation/" },
+        { icon: "linkedin", label: "LinkedIn", href: "https://www.linkedin.com/company/interledger-foundation/" },
+        { icon: "mastodon", label: "Mastadon", href: "https://interledger.social/about" },
+        {
+          icon: "slack",
+          label: "Slack",
+          href: "https://communityinviter.com/apps/interledger/interledger-working-groups-slack",
+        },
+        { icon: "x.com", label: "X.com", href: "https://twitter.com/interledger" },
+        { icon: "youtube", label: "Youtube", href: "https://www.youtube.com/@InterledgerFoundation" },
+      ],
       sidebar: [
         {
           label: "Interledger 101",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.30.1",
-    "@interledger/docs-design-system": "^0.5.5",
-    "@lorenzo_lewis/starlight-utils": "^0.2.0",
-    "astro": "^5.0.5",
-    "sharp": "^0.33.5"
+    "@astrojs/starlight": "^0.33.0",
+    "@interledger/docs-design-system": "^0.6.2",
+    "@lorenzo_lewis/starlight-utils": "^0.3.2",
+    "astro": "^5.6.1",
+    "sharp": "^0.34.1"
   }
 }


### PR DESCRIPTION
This PR bumps dependencies to the latest versions. Updates the astro.config.mjs to address the breaking change from https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md#0330