### PR TITLE
feat: add starlight-fullview-mode plugin

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightUtils from "@lorenzo_lewis/starlight-utils";
+import starlightFullViewMode from "starlight-fullview-mode";
 
 // https://astro.build/config
 export default defineConfig({
@@ -16,6 +17,7 @@ export default defineConfig({
             switcherStyle: "dropdown",
           },
         }),
+        starlightFullViewMode(),
       ],
       logo: {
         dark: "./src/assets/logo_color-white_foundation.svg",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.33.0",
-    "@interledger/docs-design-system": "^0.6.2",
+    "@astrojs/starlight": "^0.34.3",
+    "@interledger/docs-design-system": "^0.7.1",
     "@lorenzo_lewis/starlight-utils": "^0.3.2",
-    "astro": "^5.6.1",
-    "sharp": "^0.34.1"
+    "astro": "^5.7.13",
+    "sharp": "^0.34.1",
+    "starlight-fullview-mode": "^0.2.3"
   }
 }


### PR DESCRIPTION
This PR bumps dependencies to the latest versions and adds the starlight-fullview-mode plugin. Note that because of the multi sidebar, the left toggle does not appear nor work.